### PR TITLE
Add peer dependency on VueJS 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "bugs": "https://github.com/barraponto/neutrino-preset-vue/issues",
   "license": "GPL-3.0",
   "peerDependencies": {
-    "neutrino": "^5.0.0"
+    "neutrino": "^5.0.0",
+    "vue": "^2.0.0"
   },
   "devDependencies": {
     "commitizen": "^2.9.6",


### PR DESCRIPTION
VueJS should be installed as a project dependency, so the user need to be notified about that.