### PR TITLE
Babel

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,15 +2,24 @@ const arrify = require('arrify');
 const merge = require('deepmerge');
 const path = require('path');
 
-module.exports = ({ config }, options) => {
+module.exports = (neutrino, options) => {
+  const config = neutrino.config;
   const NODE_MODULES = path.join(__dirname, 'node_modules');
   const LOADER_EXTENSIONS = /\.vue$/;
   const styleRule = config.module.rules.get('style');
-  const stylePostCssLoader = styleRule && styleRule.uses.get('postcss');
+  const postCssLoader = styleRule && styleRule.uses.get('postcss');
   const lintRule = config.module.rules.get('lint');
+  const compileRule = config.module.rules.get('compile');
+  const babelLoader = compileRule && compileRule.uses.get('babel');
 
   config.module.rule('vue')
     .test(LOADER_EXTENSIONS)
+    .include
+      .merge([neutrino.options.source, neutrino.options.tests])
+      .end()
+    .exclude
+      .add(NODE_MODULES)
+      .end()
     .use('vue')
       .loader(require.resolve('vue-loader'))
       .options(options);
@@ -18,16 +27,27 @@ module.exports = ({ config }, options) => {
   config.resolve.extensions.add('.vue');
   config.resolveLoader.modules.add(NODE_MODULES);
 
-  if (stylePostCssLoader) {
-    const postcssLoaderOptions = stylePostCssLoader.get('options');
+  if (babelLoader) {
+    const babelOptions = JSON.stringify(babelLoader.get('options'));
+
+    config.module.rule('vue')
+      .use('vue')
+        .tap(options => merge({
+          loaders: {
+            js: `babel-loader?${babelOptions}`
+          }
+        }, options));
+  }
+
+  if (postCssLoader) {
+    const postcssLoaderOptions = postCssLoader.get('options');
 
     if (Object.getOwnPropertyNames(postcssLoaderOptions).length) { // check if object is not empty
-      config.module
-        .rule('vue')
+      config.module.rule('vue')
         .use('vue')
-        .tap(vueLoaderOptions => merge(vueLoaderOptions, {
-          postcss: postcssLoaderOptions
-        }));
+          .tap(vueLoaderOptions => merge(vueLoaderOptions, {
+            postcss: postcssLoaderOptions
+          }));
     }
   }
 
@@ -35,8 +55,7 @@ module.exports = ({ config }, options) => {
     // ensure conditions is an array of original values plus our own regex
     const conditions = arrify(lintRule.get('test')).concat([LOADER_EXTENSIONS]);
 
-    config.module
-      .rule('lint')
+    config.module.rule('lint')
       .test(conditions)
       .use('eslint')
         .tap(options => merge(options, {


### PR DESCRIPTION
Tha major problem was that this code was not transpiled 
```html
<template>
  <div id="app">
    Test Vue app
  </div>
</template>

<script>
  import external from '../external.js'
  import('../dinamic.js')
  console.log('test')
  Promise.resolve('promise').then(r=>console.log(r))
</script>
```
Even in case when IE was enabled the in user config
**package.json**
```json
"neutrino": {
    "use": [
      "neutrino-preset-web",
      "neutrino-preset-vue"
    ],
    "options": {
      "compile": {
        "targets": {
          "browsers": ["last 2 versions", "ie 9"]
        }
      }
    }
  },
```
Now <script> tags are processed with babel, but not the whole template.