### PR TITLE
neutrino-preset-web now use rule name 'complie'

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ const MODULES = path.join(__dirname, 'node_modules');
 module.exports = ({ config }, options) => {
   const styleRule = config.module.rules.get('style');
   const lintRule = config.module.rules.get('lint');
-  const compileRule = config.module.rules.get('compileRule');
+  const compileRule = config.module.rules.get('compile');
 
   config.module.rule('vue')
     .test(LOADER_EXTENSIONS)


### PR DESCRIPTION
When configuring babel to use object-rest-spread, using neutrino api, I found that it is not applied. The cause is that the rule name is changed from 'complieRule' to 'complie' at neutrino-preset-web.