### PR TITLE
Support object spread syntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   ],
   "dependencies": {
     "arrify": "^1.0.1",
+    "babel-plugin-transform-object-rest-spread": "^6.23.0",
     "deepmerge": "^1.4.4",
     "eslint-plugin-vue": "^2.1.0",
     "stylelint-processor-html": "^1.0.0",

--- a/src/index.js
+++ b/src/index.js
@@ -31,7 +31,12 @@ module.exports = ({ config }, options) => {
   }
 
   if (compileRule && compileRule.uses.has('babel')) {
-    const babelOptions = compileRule.use('babel').get('options');
+    const babelOptions = merge(
+      compileRule.use('babel').get('options'),
+      {
+        plugins: [ require.resolve('babel-plugin-transform-object-rest-spread') ],
+      }
+    )
     config.module
       .rule('vue')
       .use('vue')


### PR DESCRIPTION
Added Babel plugin `babel-plugin-transform-object-rest-spread` to support spread syntax. 

Necessary when implementing Vuex shorthand:

```js
import { mapGetters } from 'vuex'

export default {
  computed: {
    ...mapGetters({
      foo: 'namespace/bar',
   }),
}
```